### PR TITLE
HOTFIX: Fix frontend ESLint errors

### DIFF
--- a/frontend/src/app/addEvent/page.tsx
+++ b/frontend/src/app/addEvent/page.tsx
@@ -11,8 +11,8 @@ const AddEvent = () => {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [date, setDate] = useState<Date | null>();
-  const [contacts, setContacts] = useState<String[]>([]);
-  const [categories, setCategories] = useState<String[]>([]);
+  const [contacts, setContacts] = useState<string[]>([]);
+  const [categories, setCategories] = useState<string[]>([]);
 
   const onChangeDate = (e: ChangeEvent<HTMLInputElement>) => {
     const maybeDateString = e.target.value;

--- a/frontend/src/app/utils/arrayUtils.ts
+++ b/frontend/src/app/utils/arrayUtils.ts
@@ -1,18 +1,5 @@
 // Yer a wizard, 'Array!
 
-type Concatenable<T = any> = string | T[];
-
-export function concatWithSeparator<T extends Concatenable>(arr: T[], separator: T, resultIfEmpty: T): T {
-  if (arr == []) {
-    return resultIfEmpty;
-  }
-  let result = arr[0];
-  for (let i = 1; i < arr.length; i++) {
-    result += separator + arr[i];
-  }
-  return result;
-}
-
 export function replaceFalsyElements<T>(arr: (T | undefined | null)[], elemToReplaceWith: T): T[] {
   return arr.map(maybeT => !!maybeT ? maybeT as T : elemToReplaceWith);
 }

--- a/frontend/src/app/utils/reactStateUtils.ts
+++ b/frontend/src/app/utils/reactStateUtils.ts
@@ -1,7 +1,9 @@
 import { ChangeEvent } from "react";
 import { parseCommaSeparatedStringToList } from "@/app/utils/stringUtils";
 
-export const getOnChangeFunc_ForStringListFormElement = (setStateVariableFunction) => (e: ChangeEvent<HTMLInputElement>) => {
-  const newState = parseCommaSeparatedStringToList(e.target.value);
-  setStateVariableFunction(newState);
+export function getOnChangeFunc_ForStringListFormElement(setStateVariableFunction: (strList: string[]) => void) {
+  return (e: ChangeEvent<HTMLInputElement>) => {
+    const newState = parseCommaSeparatedStringToList(e.target.value);
+    setStateVariableFunction(newState);
+  };
 }

--- a/frontend/src/app/utils/stringUtils.ts
+++ b/frontend/src/app/utils/stringUtils.ts
@@ -1,6 +1,15 @@
-import { concatWithSeparator } from "@/app/utils/arrayUtils";
+export function concatWithSeparator(arr: string[], separator: string): string {
+  if (arr.length == 0) {
+    return "";
+  }
+  let result = arr[0];
+  for (let i = 1; i < arr.length; i++) {
+    result += separator + arr[i];
+  }
+  return result;
+}
 
-export const formatStringList = strings => concatWithSeparator(strings, " | ", "");
+export const formatStringList = (strings: string[]) => concatWithSeparator(strings, " | ");
 
 export const parseCommaSeparatedStringToList = (commaSeparatedString: string): string[] => {
   return commaSeparatedString


### PR DESCRIPTION
Fixed a few ESLint type errors.

The original problem is that my IDE doesn't like ESLint for some reason. (No idea why. I've tried to fix it; never succeeded.) So a combination of 1) my IDE's limited built-in typechecking, 2) how `next dev` skips lint checks, and 3) JavaScript's "I-don't-care-if-it-doesn't-compile-just-do-it-anyway" worldview, meant that it always worked with no error messages.